### PR TITLE
Fixed PS4 build

### DIFF
--- a/include/fmt/posix.h
+++ b/include/fmt/posix.h
@@ -21,8 +21,10 @@
 
 #include <cstddef>
 
+#if !defined __ORBIS__
 #if defined __APPLE__ || defined(__FreeBSD__)
 # include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#endif
 #endif
 
 #include "format.h"
@@ -241,6 +243,7 @@ class file {
   // Attempts to write count bytes from the specified buffer to the file.
   FMT_API std::size_t write(const void *buffer, std::size_t count);
 
+#if !defined __ORBIS__
   // Duplicates a file descriptor with the dup function and returns
   // the duplicate as a file object.
   FMT_API static file dup(int fd);
@@ -256,14 +259,17 @@ class file {
   // Creates a pipe setting up read_end and write_end file objects for reading
   // and writing respectively.
   FMT_API static void pipe(file &read_end, file &write_end);
+#endif
 
   // Creates a buffered_file object associated with this file and detaches
   // this file object from the file.
   FMT_API buffered_file fdopen(const char *mode);
 };
 
+#if !defined __ORBIS__
 // Returns the memory page size.
 long getpagesize();
+#endif
 
 #if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
     !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__) && \

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -169,6 +169,7 @@ std::size_t file::write(const void *buffer, std::size_t count) {
   return internal::to_unsigned(result);
 }
 
+#if !defined __ORBIS__
 file file::dup(int fd) {
   // Don't retry as dup doesn't return EINTR.
   // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
@@ -216,6 +217,7 @@ void file::pipe(file &read_end, file &write_end) {
   read_end = file(fds[0]);
   write_end = file(fds[1]);
 }
+#endif
 
 buffered_file file::fdopen(const char *mode) {
   // Don't retry as fdopen doesn't return EINTR.
@@ -228,6 +230,7 @@ buffered_file file::fdopen(const char *mode) {
   return bf;
 }
 
+#if !defined __ORBIS__
 long getpagesize() {
 #ifdef _WIN32
   SYSTEM_INFO si;
@@ -240,5 +243,6 @@ long getpagesize() {
   return size;
 #endif
 }
+#endif
 FMT_END_NAMESPACE
 


### PR DESCRIPTION
A number of system calls used in fmt aren't available on PS4. This patch disables a few functions that rely on these. Luckily, they don't seem to be used internally by fmt.